### PR TITLE
Fix error handling for run sequence errors

### DIFF
--- a/flow/sequencer.go
+++ b/flow/sequencer.go
@@ -83,7 +83,7 @@ func (s *Sequencer) Run(
 
 	isPassing, err := s.runSequence(ctx, seq, cancelTest, testId)
 	if err != nil {
-		testErrors := s.testErrors
+		testErrors := append(s.testErrors, errors.Wrap(err, "run sequence"))
 		s.testErrors = []error{}
 
 		return false, s.failedTags, testErrors, errors.Wrap(err, "run sequence")


### PR DESCRIPTION
This type of error was only showing up in logs. Now it will show up in the error page.